### PR TITLE
fix(css): Remove extra space between tabs due to use of 'inline-block' in '.ui-tabs-scrollable .nav > li'

### DIFF
--- a/angular-ui-tab-scroll.css
+++ b/angular-ui-tab-scroll.css
@@ -20,6 +20,7 @@
 }
 
 .ui-tabs-scrollable .nav > li {
+  margin-right: -4px;
   float: none;
   display: inline-block;
   height: 42px!important;


### PR DESCRIPTION
fixes #3
