### PR TITLE
chore(bower): add 'angular-ui-tab-scroll.css' to bower.json 's main 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ui-tab-scroll",
-  "main": "angular-ui-tab-scroll.js",
+  "main": ["angular-ui-tab-scroll.js","angular-ui-tab-scroll.css"],
   "version": "0.1.0",
   "homepage": "https://github.com/VersifitTechnologies/angular-ui-tab-scroll",
   "authors": [


### PR DESCRIPTION
Added **'angular-ui-tab-scroll.css'** to bower.json 's **main section**.

This allows build tools like [grunt-wiredep](https://github.com/stephenplusplus/grunt-wiredep) to automatically add the css dependency (as well as the js) in the index.html during build process. Pretty handy!
