### PR TITLE
fix(navbuttons): explicitly set left/right navigation buttons 'type' attribute to 'button'

### DIFF
--- a/angular-ui-tab-scroll.js
+++ b/angular-ui-tab-scroll.js
@@ -59,11 +59,11 @@ angular.module('ui.tab.scroll', [])
 
       template: [
         '<div class="ui-tabs-scrollable">',
-          '<button ng-hide="hideButtons" ng-disabled="disableLeft()" class="btn nav-button left-nav-button" tooltip-placement="{{tooltipLeftDirection()}}" tooltip-html-unsafe="{{tooltipLeftContent()}}">',
+          '<button type="button" ng-hide="hideButtons" ng-disabled="disableLeft()" class="btn nav-button left-nav-button" tooltip-placement="{{tooltipLeftDirection()}}" tooltip-html-unsafe="{{tooltipLeftContent()}}">',
             '<span class="glyphicon glyphicon-chevron-left"></span>',
           '</button>',
           '<div class="spacer" ng-class="{\'hidden-buttons\': hideButtons}" ng-transclude></div>',
-          '<button ng-hide="hideButtons" ng-disabled="disableRight()" class="btn nav-button right-nav-button" tooltip-placement="{{tooltipRightDirection()}}" tooltip-html-unsafe="{{tooltipRightContent()}}">',
+          '<button type="button" ng-hide="hideButtons" ng-disabled="disableRight()" class="btn nav-button right-nav-button" tooltip-placement="{{tooltipRightDirection()}}" tooltip-html-unsafe="{{tooltipRightContent()}}">',
             '<span class="glyphicon glyphicon-chevron-right"></span>',
           '</button>',
         '</div>'


### PR DESCRIPTION
As stated in the [W3 Specification for HTML5](http://w3c.github.io/html-reference/button.html): 

> A button element with no type attribute specified represents the same thing as a button element with its type attribute set to "submit".

This caused any form inside the wrapped tabs **to be wrongly submitted** when clicking on navigation buttons.

Besides it's a best practise to always specify the type attribute for the <button> element, given that browsers may use different default types for the <button> element.
