### PR TITLE
fix(api): fix API initialization issue by watching wrapped tabset's tabs collection

### DIFF
--- a/angular-ui-tab-scroll.js
+++ b/angular-ui-tab-scroll.js
@@ -200,10 +200,16 @@ angular.module('ui.tab.scroll', [])
         //hello my friend jake weary
         $(window).on('resize', initAndApply);
 
-        //even if one doesn't exist, we can still initialize w/ this
-        $scope.$watch(function(){return $scope.watchExpression;}, function() {
-          $timeout(initAndApply, 0);
-        }, true);
+        //we initialize by watching changes on the inner tabset's tabs collection
+        var tabsetElem = angular.element($el[0].querySelector( 'div.spacer' )).children()[0];//get the wrapped 'tabset'
+        var $tabsetElem = angular.element(tabsetElem);
+        var tabsetScope = $tabsetElem.isolateScope() || $tabsetElem.scope();// get the tabset's scope to access to tabs collection
+
+        $scope.$watchCollection(function(){
+            return tabsetScope.tabs;
+          }, function(newValues, oldValues){
+            $timeout(initAndApply, 0);
+        });
 
       }
     };


### PR DESCRIPTION
Hi,

I came across another issue, due to the way the API is currently initialized.

> when tabs are added dynamically into the tabset after the first initialization (for .i.e  when tabs are added after a server call returns or after a late binding), the API gets no longer initialized to consider the new tabs.

The issue is illustrated in this [plunker](http://plnkr.co/edit/AmS50LpdzyKOXm3VfaaY?p=preview): 

A solution is  to watch the _tabs_ collections from the wrapped _tabset_ directive.

The solution is illustrated in this [plunker](http://plnkr.co/edit/tbgkKyFn2RM3neAoeu6x?p=preview): 
