### PR TITLE
Lock to compatible version of angular-bootstrap

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
   "dependencies": {
     "bootstrap": ">=3.3.4",
     "angular": ">=1.3.0",
-    "angular-bootstrap": ">=0.13.0"
+    "angular-bootstrap": "0.13.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
   "dependencies": {
     "bootstrap": ">=3.3.4",
     "angular": ">=1.3.0",
-    "angular-bootstrap": "0.13.0"
+    "angular-bootstrap": ">=0.13.0 <1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "bootstrap": ">=3.3.4",
     "angular": ">=1.3.0",
-    "angular-ui-bootstrap": ">=0.13.0"
+    "angular-ui-bootstrap": ">=0.13.0 <1.0.0"
   },
   "bugs": {
     "url": "https://github.com/VersifitTechnologies/angular-ui-tab-scroll/issues"


### PR DESCRIPTION
angular-ui-tab-scroll does not work with the latest versions of angular-bootstrap, >1.0.0 ([plunkr](http://plnkr.co/edit/Dj3qrL7K3PTR4dsH0z5P)).

Both `bower.json` and `package.json` declare the dependency as `"angular-ui-bootstrap": ">=0.13.0"`, which ends up downloading the latest one and breaking.
