### PR TITLE
ngRouter has issues with "#" on the dropdown menu

### DIFF
--- a/angular-ui-tab-scroll.js
+++ b/angular-ui-tab-scroll.js
@@ -84,7 +84,7 @@ angular.module('ui.tab.scroll', [])
                 '<button type="button" class="btn" dropdown-toggle></button>',
                 '<ul class="dropdown-menu dropdown-menu-right" role="menu" aria-labelledby="single-button">',
                   '<li role="menuitem" ng-repeat="tab in dropdownTabs" ng-class="{\'disabled\': tab.disabled}" ng-click="activateTab(tab)">',
-                    '<a href="#"><span class="dropDownTabActiveMark" ng-style="{\'visibility\': tab.active?\'visible\':\'hidden\'}"></span>{{tab.tabScrollTitle}}</a>',
+                    '<a href><span class="dropDownTabActiveMark" ng-style="{\'visibility\': tab.active?\'visible\':\'hidden\'}"></span>{{tab.tabScrollTitle}}</a>',
                   '</li>',
                 '</ul>',
               '</div>',


### PR DESCRIPTION
When creating the dropdown menu, the template creates one `<li>` with one `<a href="#">` inside for each tab. Despite appearing on the [bootstrap examples](https://getbootstrap.com/components/#btn-dropdowns), the `#` is completely unnecessary for functionality and can cause some problems since the elements are dynamically created by the lib and can't be easily accessed. 

Possible alternatives to this commit would be:
-  `<a href="#" ng-click="$event.preventDefault()" ...` 
-  `<a ...` (completely removing the href) + `a { cursor: pointer; }` (and a proper selector)

But the one proposed here seemed more... elegant.
